### PR TITLE
Improve output stats readability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'colorize'
+gem 'terminal-table'
 
 group :test do
   gem 'rspec'

--- a/helpers.rb
+++ b/helpers.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'benchmark'
+
+def profile_memory
+  memory_usage_before = `ps -o rss= -p #{Process.pid}`.to_i
+  yield
+  memory_usage_after = `ps -o rss= -p #{Process.pid}`.to_i
+
+  used_memory = ((memory_usage_after - memory_usage_before) / 1024.0).round(2)
+  puts "Memory usage: #{used_memory} MB"
+end
+
+def profile_time
+  time_elapsed = Benchmark.realtime do
+    yield
+  end
+
+  puts "Time: #{time_elapsed.round(2)} seconds"
+end
+
+def profile_gc
+  GC.start
+  before = GC.stat(:total_freed_objects)
+  yield
+  GC.start
+  after = GC.stat(:total_freed_objects)
+
+  puts "Objects Freed: #{after - before}"
+end
+
+def profile
+  profile_memory do
+    profile_time do
+      profile_gc do
+        yield
+      end
+    end
+  end
+end

--- a/lib/log/printer.rb
+++ b/lib/log/printer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'terminal-table'
+
 module Log
   # Prints calculated page visits statistic
   class Printer
@@ -9,9 +11,8 @@ module Log
     end
 
     def call
-      print_lines.each do |line|
-        output.puts line
-      end
+      puts visits_table
+      puts uniq_views_table
     end
 
     private
@@ -19,32 +20,30 @@ module Log
     attr_reader :statistic, :output
     alias stats statistic
 
-    def print_lines
-      visits_lines + uniq_view_lines
+    def visits_table
+      Terminal::Table.new headings: %w[Path Count Message], rows: visits_rows
     end
 
-    def visits_lines
+    def uniq_views_table
+      Terminal::Table.new headings: %w[Path Count Message], rows: uniq_view_rows
+    end
+
+    def visits_rows
       stats.most_visits.map do |stat|
-        Line.new(stat[0], stat[1], 'visit')
+        message = pluralize('visit', stat[1])
+        stat + [message]
       end
     end
 
-    def uniq_view_lines
-      stats.most_uniq_views.map do |stat|
-        Line.new(stat[0], stat[1], 'unique view')
+    def uniq_view_rows
+      stats.most_visits.map do |stat|
+        message = pluralize('unique view', stat[1])
+        stat + [message]
       end
     end
 
-    Line = Struct.new(:path, :count, :message) do
-      def to_s
-        "#{path} #{count} #{postfix}"
-      end
-
-      def postfix
-        return message + 's' if count > 1
-
-        message
-      end
+    def pluralize(word, count)
+      count > 1 ? "#{word}s" : word
     end
   end
 end

--- a/spec/log/printer_spec.rb
+++ b/spec/log/printer_spec.rb
@@ -19,12 +19,20 @@ RSpec.describe Log::Printer do
   describe '#call' do
     let(:expected_output) do
       <<~OUTPUT
-        /contact 3 visits
-        /about 2 visits
-        /home 1 visit
-        /contact 2 unique views
-        /about 2 unique views
-        /home 1 unique view
+        +----------+-------+---------+
+        | Path     | Count | Message |
+        +----------+-------+---------+
+        | /contact | 3     | visits  |
+        | /about   | 2     | visits  |
+        | /home    | 1     | visit   |
+        +----------+-------+---------+
+        +----------+-------+--------------+
+        | Path     | Count | Message      |
+        +----------+-------+--------------+
+        | /contact | 3     | unique views |
+        | /about   | 2     | unique views |
+        | /home    | 1     | unique view  |
+        +----------+-------+--------------+
       OUTPUT
     end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -5,12 +5,20 @@ RSpec.describe 'parser.rb' do
     let(:log_path) { fixture_path('logs/valid.log') }
     let(:expected_output) do
       <<~OUTPUT
-        /contact 3 visits
-        /about 2 visits
-        /home 1 visit
-        /contact 2 unique views
-        /about 2 unique views
-        /home 1 unique view
+        +----------+-------+---------+
+        | Path     | Count | Message |
+        +----------+-------+---------+
+        | /contact | 3     | visits  |
+        | /about   | 2     | visits  |
+        | /home    | 1     | visit   |
+        +----------+-------+---------+
+        +----------+-------+--------------+
+        | Path     | Count | Message      |
+        +----------+-------+--------------+
+        | /contact | 3     | unique views |
+        | /about   | 2     | unique views |
+        | /home    | 1     | unique view  |
+        +----------+-------+--------------+
       OUTPUT
     end
 


### PR DESCRIPTION
## Why?
The old format doesn't seem to be easily readable by human

## What?
Improve output readability to better differentiate the stats information and separate the information blocks.

![Screen Shot 2020-04-05 at 1 12 09 PM](https://user-images.githubusercontent.com/4772270/78472182-689d3680-773f-11ea-8dae-874d7e3d4494.png)
