### PR TITLE
Simplify table print (remove unneeded column)

### DIFF
--- a/lib/log/printer.rb
+++ b/lib/log/printer.rb
@@ -21,29 +21,19 @@ module Log
     alias stats statistic
 
     def visits_table
-      Terminal::Table.new headings: %w[Path Count Message], rows: visits_rows
+      Terminal::Table.new headings: %w[Path Visits], rows: visits_rows
     end
 
     def uniq_views_table
-      Terminal::Table.new headings: %w[Path Count Message], rows: uniq_view_rows
+      Terminal::Table.new headings: ['Path', 'Unique views'], rows: uniq_view_rows
     end
 
     def visits_rows
-      stats.most_visits.map do |stat|
-        message = pluralize('visit', stat[1])
-        stat + [message]
-      end
+      stats.most_visits
     end
 
     def uniq_view_rows
-      stats.most_visits.map do |stat|
-        message = pluralize('unique view', stat[1])
-        stat + [message]
-      end
-    end
-
-    def pluralize(word, count)
-      count > 1 ? "#{word}s" : word
+      stats.most_uniq_views
     end
   end
 end

--- a/spec/log/printer_spec.rb
+++ b/spec/log/printer_spec.rb
@@ -19,20 +19,20 @@ RSpec.describe Log::Printer do
   describe '#call' do
     let(:expected_output) do
       <<~OUTPUT
-        +----------+-------+---------+
-        | Path     | Count | Message |
-        +----------+-------+---------+
-        | /contact | 3     | visits  |
-        | /about   | 2     | visits  |
-        | /home    | 1     | visit   |
-        +----------+-------+---------+
-        +----------+-------+--------------+
-        | Path     | Count | Message      |
-        +----------+-------+--------------+
-        | /contact | 3     | unique views |
-        | /about   | 2     | unique views |
-        | /home    | 1     | unique view  |
-        +----------+-------+--------------+
+        +----------+--------+
+        | Path     | Visits |
+        +----------+--------+
+        | /contact | 3      |
+        | /about   | 2      |
+        | /home    | 1      |
+        +----------+--------+
+        +----------+--------------+
+        | Path     | Unique views |
+        +----------+--------------+
+        | /contact | 2            |
+        | /about   | 2            |
+        | /home    | 1            |
+        +----------+--------------+
       OUTPUT
     end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe 'parser.rb' do
     let(:log_path) { fixture_path('logs/valid.log') }
     let(:expected_output) do
       <<~OUTPUT
-        +----------+-------+---------+
-        | Path     | Count | Message |
-        +----------+-------+---------+
-        | /contact | 3     | visits  |
-        | /about   | 2     | visits  |
-        | /home    | 1     | visit   |
-        +----------+-------+---------+
-        +----------+-------+--------------+
-        | Path     | Count | Message      |
-        +----------+-------+--------------+
-        | /contact | 3     | unique views |
-        | /about   | 2     | unique views |
-        | /home    | 1     | unique view  |
-        +----------+-------+--------------+
+        +----------+--------+
+        | Path     | Visits |
+        +----------+--------+
+        | /contact | 3      |
+        | /about   | 2      |
+        | /home    | 1      |
+        +----------+--------+
+        +----------+--------------+
+        | Path     | Unique views |
+        +----------+--------------+
+        | /contact | 2            |
+        | /about   | 2            |
+        | /home    | 1            |
+        +----------+--------------+
       OUTPUT
     end
 


### PR DESCRIPTION
### What?
Simplify table report printing to reduce the unneeded column, it also simplifies and reduces the complexity of the code.

![Screen Shot 2020-04-05 at 3 26 33 PM](https://user-images.githubusercontent.com/4772270/78493964-f8e47700-7751-11ea-8a3d-fb16c9750ef4.png)
